### PR TITLE
Update cs-rin-ru-enhanced-mod.user.js

### DIFF
--- a/cs-rin-ru-enhanced-mod.user.js
+++ b/cs-rin-ru-enhanced-mod.user.js
@@ -5,7 +5,7 @@
 // @name:fr         CS.RIN.RU Amélioré
 // @name:pt         CS.RIN.RU Melhorado
 // @namespace       Royalgamer06
-// @version         0.7.18
+// @version         0.7.19
 // @description     Enhance your experience at CS.RIN.RU - Steam Underground Community.
 // @description:fr  Améliorez votre expérience sur CS.RIN.RU - Steam Underground Community.
 // @description:pt  Melhorar a sua experiência no CS.RIN.RU - Steam Underground Community.
@@ -92,7 +92,7 @@ let options = {
     "copy_link_button": true,
     "add_small_shoutbox": true,
     "add_users_tag": true,
-    "go_to_unread_posts": 1 //0= dont go, 1=go to, 2=go to + preview
+    "go_to_unread_posts": 0 //0= dont go, 1=go to, 2=go to + preview
 };
 
 /*


### PR DESCRIPTION
go_to_unread_posts sets to 0 by default now.

I thought of this thanks to https://github.com/SubZeroPL/cs-rin-ru-enhanced-mod/issues/23
Indeed, for a normal user who doesn't touch the configuration, it can be confusing. So I think it's better to remove it by default.