### PR TITLE
Fix for navbar on Firefox

### DIFF
--- a/cs-rin-ru-enhanced-mod.user.js
+++ b/cs-rin-ru-enhanced-mod.user.js
@@ -180,7 +180,7 @@ if (navBar) {
     div.setAttribute("width", "500"); // Standardised width
     div.innerHTML = navBar.innerHTML; // Copy the navigation bar
     navBar.parentNode.replaceChild(div, navBar); // Replace the existing navigation bar with the modified one
-    const ancestor = $(td).closest("#pagecontent, #pageheader"); // #pagecontent for viewforum.php, #pageheader for viewtopic.php
+    const ancestor = $(div).closest("#pagecontent, #pageheader"); // #pagecontent for viewforum.php, #pageheader for viewtopic.php
     if (ancestor.length) {
         $("#pagecontent").before(div);
     } else {

--- a/cs-rin-ru-enhanced-mod.user.js
+++ b/cs-rin-ru-enhanced-mod.user.js
@@ -5,7 +5,7 @@
 // @name:fr         CS.RIN.RU Amélioré
 // @name:pt         CS.RIN.RU Melhorado
 // @namespace       Royalgamer06
-// @version         0.10.2
+// @version         0.10.3
 // @description     Enhance your experience at CS.RIN.RU - Steam Underground Community.
 // @description:fr  Améliorez votre expérience sur CS.RIN.RU - Steam Underground Community.
 // @description:pt  Melhorar a sua experiência no CS.RIN.RU - Steam Underground Community.

--- a/cs-rin-ru-enhanced-mod.user.js
+++ b/cs-rin-ru-enhanced-mod.user.js
@@ -112,7 +112,7 @@ Functions that need to be connected must be added here and you must also add the
 */
 function loadConfig() {
     const savedOptions = GM_getValue("options", options);
-    options = {...options, ...savedOptions};
+    options = { ...options, ...savedOptions };
     if (!CONNECTED) {
         options.dynamic_function = false;
         options.add_profile_button = false;
@@ -174,17 +174,17 @@ if (!options.script_enabled) return;
 // Navigation bar
 let navBar = $("[title='Click to jump to page…']").parent().parent().first()[0]; // Gets the first navigation bar
 if (navBar) {
-    const td = document.createElement("td"); // Necessary for search.php
-    td.setAttribute("class", "gensmall"); // Necessary for search.php
-    td.setAttribute("name", "page_nav"); // Makes it easier for the GM_addStyle function
-    td.setAttribute("width", "500"); // Standardised width
-    td.innerHTML = navBar.innerHTML; // Copy the navigation bar
-    navBar.parentNode.replaceChild(td, navBar); // Replace the existing navigation bar with the modified one
+    const div = document.createElement("div"); // Necessary for search.php
+    div.setAttribute("class", "gensmall"); // Necessary for search.php
+    div.setAttribute("name", "page_nav"); // Makes it easier for the GM_addStyle function
+    div.setAttribute("width", "500"); // Standardised width
+    div.innerHTML = navBar.innerHTML; // Copy the navigation bar
+    navBar.parentNode.replaceChild(div, navBar); // Replace the existing navigation bar with the modified one
     const ancestor = $(td).closest("#pagecontent, #pageheader"); // #pagecontent for viewforum.php, #pageheader for viewtopic.php
     if (ancestor.length) {
-        $("#pagecontent").before(td);
+        $("#pagecontent").before(div);
     } else {
-        $("[method='post']:not(#search)").get(0).before(td); // For search.php, memberlist.php
+        $("[method='post']:not(#search)").get(0).before(div); // For search.php, memberlist.php
     }
 
     GM_addStyle(`[name="page_nav"] {
@@ -231,7 +231,7 @@ if (options.infinite_scrolling && $("[title='Click to jump to page…']").length
     const scrollThreshold = 1000; // Approximately 10 clicks of the scroll wheel
 
     let navElems = {}; // Dictionary for storing nav elements for each page (page number: {Html: HTML of that page's nav element)
-    navElems[$(navElem).find("strong").text()] = {Html: navElem.html()}; // Add the current nav element to the dictionary
+    navElems[$(navElem).find("strong").text()] = { Html: navElem.html() }; // Add the current nav element to the dictionary
 
     if (URLContains("viewtopic.php")) {
         if (nextElem.length !== 0) { // If we're not on the last page
@@ -251,7 +251,7 @@ if (options.infinite_scrolling && $("[title='Click to jump to page…']").length
                 $(page[0]).find("tbody:first").find("tr:first").remove();
                 $(selector).last().after(page);
                 const nextNavElemHTML = $("[title='Click to jump to page…']", data).first().parent().html();
-                navElems[$(nextElem).text()] = {Html: nextNavElemHTML};
+                navElems[$(nextElem).text()] = { Html: nextNavElemHTML };
                 functionsCalledByInfiniteScrolls(data);
                 nextElem = $(navElem).find("strong").next().next().next().next();
                 nextPage = $(nextElem).attr("href");
@@ -270,9 +270,9 @@ if (options.infinite_scrolling && $("[title='Click to jump to page…']").length
                     $($(selector)[0]).before($(selector, data).attr("page_number", $(previousElem).text()));
                     let top = $(element[0]).offset().top + $(element[0]).height();
                     const scrollPosition = top - $(window).height();
-                    $('html, body').animate({scrollTop: scrollPosition}, 0);
+                    $('html, body').animate({ scrollTop: scrollPosition }, 0);
                     const prevNavElemHTML = $("[title='Click to jump to page…']", data).first().parent().html();
-                    navElems[$(previousElem).text()] = {Html: prevNavElemHTML};
+                    navElems[$(previousElem).text()] = { Html: prevNavElemHTML };
                     functionsCalledByInfiniteScrolls(data);
                     previousElem = $(navElem).find("strong").prev().prev().prev().prev();
                     prevPage = $(previousElem).attr("href");


### PR DESCRIPTION
The navbar originally was contained in table cell element (`<td>`). Modification to make navbar sticky moved the `<td>` element outside `<table>` element, which produced invalid html markup, but apparently Chrome does not care about it, while Firefox does. 
That's why it was working for you @Reddiepoint (you are using Chrome/Tampermonkey as I recall) and not for me (Firefox/Violentmonkey).
This change creates `<div>` container for floating navbar instead of `<td>` container, which is correct html markup and as a result works fine in Firefox.